### PR TITLE
docs(readme): fix markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # Matin-s-Todo-List
+
 This project includes the following features:
--Create ( create new item )
--Read ( show a list of created items )
--Delete ( delete todo item )
--Filter ( show only done items / show all items )
--Update ( click checkbox and save done/undone state )
+
+- Create ( create new item )
+- Read ( show a list of created items )
+- Delete ( delete todo item )
+- Filter ( show only done items / show all items )
+- Update ( click checkbox and save done/undone state )
 
 *in this project Information is stored on a local server
 
 ![photo_2022-01-15_15-54-38](https://user-images.githubusercontent.com/97735503/149621661-cd6eb04b-e82b-4741-a504-78af8e8dedf6.jpg)
 ![photo_2022-01-15_15-54-42](https://user-images.githubusercontent.com/97735503/149621664-d34a2b64-5b30-4d07-8444-642b62b943cf.jpg)
 ![photo_2022-01-15_15-53-58](https://user-images.githubusercontent.com/97735503/149621666-a32f1396-9138-40ff-b6d6-47ae8078f49f.jpg)
+a


### PR DESCRIPTION
Dear Matin,

It's necessary to put an space after each dash in markdown lists, merge the pull request and check your readme file again for changes